### PR TITLE
Remove recursive call from findSlabClassIndex function

### DIFF
--- a/slab_test.go
+++ b/slab_test.go
@@ -1,5 +1,6 @@
 package slab
 
+/* test guogaofeng */
 import (
 	"sort"
 	"testing"


### PR DESCRIPTION
The chunkSize of each slabClass in slabClasses array is in ascending
order. After calling sort.Search(), if we can't find a large enough
slabClass, we could append larger slabClass to slabClasses circularly
until the one fits the bufLen.

Recursive implementation induces unnecessary comparison in binary-
searching and cost in function call stack.